### PR TITLE
Update some type declaration to avoid confusion. Types within EDO should be explicit and consistent with the actual type.

### DIFF
--- a/Service/Sources/EDOClientService+Private.h
+++ b/Service/Sources/EDOClientService+Private.h
@@ -36,8 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** Get the reference of a distant object of the given @c remoteAddress. */
 + (EDOObject *)distantObjectReferenceForRemoteAddress:(EDOPointerType)remoteAddress;
 
-/** Add the reference of the given distant object */
-+ (void)addDistantObjectReference:(EDOObject *)object;
+/** Add reference of given distant object. It could be an EDOObject or dummy block object. */
++ (void)addDistantObjectReference:(id)object;
 
 /** Remove the reference of a distant object of the given @c remoteAddress. */
 + (void)removeDistantObjectReference:(EDOPointerType)remoteAddress;

--- a/Service/Sources/EDOClientService.m
+++ b/Service/Sources/EDOClientService.m
@@ -75,11 +75,9 @@
   return result;
 }
 
-+ (void)addDistantObjectReference:(EDOObject *)object {
-  EDOObject *edoObject = object;
-  if ([EDOBlockObject isBlock:object]) {
-    edoObject = [EDOBlockObject EDOBlockObjectFromBlock:object];
-  }
++ (void)addDistantObjectReference:(id)object {
+  EDOObject *edoObject =
+      [EDOBlockObject isBlock:object] ? [EDOBlockObject EDOBlockObjectFromBlock:object] : object;
   NSNumber *edoKey = [NSNumber numberWithLongLong:edoObject.remoteAddress];
   dispatch_sync(self.edoSyncQueue, ^{
     [self.localDistantObjects setObject:object forKey:edoKey];
@@ -170,10 +168,8 @@
 }
 
 + (id)cachedEDOFromObjectUpdateIfNeeded:(id)object {
-  EDOObject *edoObject = object;
-  if ([EDOBlockObject isBlock:object]) {
-    edoObject = [EDOBlockObject EDOBlockObjectFromBlock:object];
-  }
+  EDOObject *edoObject =
+      [EDOBlockObject isBlock:object] ? [EDOBlockObject EDOBlockObjectFromBlock:object] : object;
   Class objClass = object_getClass(edoObject);
   if (objClass == [EDOObject class] || objClass == [EDOBlockObject class]) {
     id localObject = [self distantObjectReferenceForRemoteAddress:edoObject.remoteAddress];

--- a/Service/Sources/EDOObjectAliveMessage.m
+++ b/Service/Sources/EDOObjectAliveMessage.m
@@ -24,8 +24,9 @@ static NSString *const kEDOObjectAliveCoderObjectKey = @"object";
 #pragma mark -
 
 @interface EDOObjectAliveRequest ()
-/** The EDOObject that needs to check if its underlying object is alive. */
-@property(readonly) EDOObject *object;
+// The proxy object that needs to check if its underlying object is alive. It could either be an
+// EDOObject or block object.
+@property(readonly) id object;
 @end
 
 #pragma mark -
@@ -56,10 +57,9 @@ static NSString *const kEDOObjectAliveCoderObjectKey = @"object";
 + (EDORequestHandler)requestHandler {
   return ^(EDOServiceRequest *request, EDOHostService *service) {
     EDOObjectAliveRequest *retainRequest = (EDOObjectAliveRequest *)request;
-    EDOObject *object = retainRequest.object;
-    if ([EDOBlockObject isBlock:object]) {
-      object = [EDOBlockObject EDOBlockObjectFromBlock:object];
-    }
+    EDOObject *object = [EDOBlockObject isBlock:retainRequest.object]
+                            ? [EDOBlockObject EDOBlockObjectFromBlock:retainRequest.object]
+                            : retainRequest.object;
     object = [service isObjectAlive:object] ? object : nil;
     return [EDOObjectAliveResponse responseWithObject:object forRequest:request];
   };

--- a/Service/Sources/EDOObjectMessage.h
+++ b/Service/Sources/EDOObjectMessage.h
@@ -31,11 +31,11 @@ NS_ASSUME_NONNULL_BEGIN
 /** The object response for the object request. */
 @interface EDOObjectResponse : EDOServiceResponse
 /**
- *  The requested distant object.
+ *  The requested distant object. This could be either an EDOObject or a block object.
  *
  *  @note It is possible the distant object is nil, for example, the underlying object is gone.
  */
-@property(readonly, nullable) EDOObject *object;
+@property(readonly, nullable) id object;
 
 + (EDOServiceResponse *)responseWithObject:(EDOObject *_Nullable)object
                                 forRequest:(EDOServiceRequest *)request;

--- a/Service/Tests/FunctionalTests/EDOServiceUITest.m
+++ b/Service/Tests/FunctionalTests/EDOServiceUITest.m
@@ -140,8 +140,8 @@
 }
 
 /*
- Test that makes sure local block is resolved to its address, when it is decoded from the session
- which is different from the session it is encoded.
+ Test that makes sure local block is resolved to its address, when it is decoded from the service
+ which is different from the service it is encoded.
  */
 - (void)testBlockResolveToLocalAddress {
   [self launchAppWithPort:EDOTEST_APP_SERVICE_PORT initValue:10];

--- a/Service/Tests/FunctionalTests/EDOSwiftUITest.swift
+++ b/Service/Tests/FunctionalTests/EDOSwiftUITest.swift
@@ -17,6 +17,10 @@
 import Foundation
 import XCTest
 
+import third_party_objective_c_eDistantObject_Service_Service
+import third_party_objective_c_eDistantObject_Service_Tests_TestsBundle_TestsBundleHeader
+import third_party_objective_c_eDistantObject_Service_Tests_TestsBundle_TestsSwiftProtocol
+
 class EDOSwiftUITest: XCTestCase {
   @discardableResult
   func launchAppWithPort(port : Int, value : Int) -> XCUIApplication {

--- a/Service/Tests/TestsBundle/EDOTestSwiftClass.swift
+++ b/Service/Tests/TestsBundle/EDOTestSwiftClass.swift
@@ -16,6 +16,9 @@
 
 import Foundation
 
+import third_party_objective_c_eDistantObject_Service_Tests_TestsBundle_TestsBundleHeader
+import third_party_objective_c_eDistantObject_Service_Tests_TestsBundle_TestsSwiftProtocol
+
 @objc
 public class EDOTestSwiftClass : NSObject, EDOTestSwiftProtocol {
   public func returnString() -> NSString {

--- a/Service/Tests/UnitTests/EDOMessageTest.m
+++ b/Service/Tests/UnitTests/EDOMessageTest.m
@@ -50,9 +50,10 @@
                                                   [EDOObjectRequest request], service);
                                           XCTAssertEqualObjects([response class],
                                                                 [EDOObjectResponse class]);
-                                          XCTAssertEqual(response.object.remoteAddress,
+                                          EDOObject *object = response.object;
+                                          XCTAssertEqual(object.remoteAddress,
                                                          (EDOPointerType)dummyLocal);
-                                          XCTAssertEqual(response.object.remoteClass,
+                                          XCTAssertEqual(object.remoteClass,
                                                          (EDOPointerType)[dummyLocal class]);
                                           [blockExecuted fulfill];
                                         }];
@@ -74,9 +75,10 @@
                                                     request, service);
                                             XCTAssertEqualObjects([response class],
                                                                   [EDOClassResponse class]);
-                                            XCTAssertTrue(response.object.remoteAddress ==
+                                            EDOObject *object = response.object;
+                                            XCTAssertTrue(object.remoteAddress ==
                                                           (EDOPointerType)[dummyLocal class]);
-                                            XCTAssertTrue(response.object.remoteClass ==
+                                            XCTAssertTrue(object.remoteClass ==
                                                           (EDOPointerType)dummyMeta);
                                           }
 


### PR DESCRIPTION
Update some type declaration to avoid confusion. Types within EDO should be explicit and consistent with the actual type.