### PR TITLE
Adding @escaping - the newer swift compiler (Xcode 10) seeing it as the block is invoked outside the function scope if it's in obj-c, or invoked in an obj-c manner.

### DIFF
--- a/Channel/Sources/EDOSocket.m
+++ b/Channel/Sources/EDOSocket.m
@@ -137,7 +137,6 @@ static void edo_RunHandlerWithErrorInQueueWithBlock(int code, dispatch_queue_t q
       edo_RunHandlerWithErrorInQueueWithBlock(connectError, queue, block);
     } else {
       // Prevent SIGPIPE, suggested by Apple.
-      // NOLINTNEXTLINE
       // https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/CommonPitfalls/CommonPitfalls.html
       int on = 1;
       setsockopt(socketFD, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));

--- a/Service/Sources/EDOExecutor.m
+++ b/Service/Sources/EDOExecutor.m
@@ -192,7 +192,7 @@ static const int64_t kPingTimeoutSeconds = 10 * NSEC_PER_SEC;
       NSAssert(messages.count == 3 || messages.count == 4,
                @"The message can be either two elements or three elements with a context.");
 
-      // [0]: the request; [1]: the channel; [2]: the context [3]: the wait lock of receiving data.
+      // [0]: the request; [1]: the channel; [2]: the wait-lock of receiving data; [3]: the context.
       [self edo_handleRequest:(EDOServiceRequest *)messages[0]
                   withChannel:messages[1]
                       context:(messages.count > 3 ? messages[3] : nil)];


### PR DESCRIPTION
Adding @escaping - the newer swift compiler (Xcode 10) seeing it as the block is invoked outside the function scope if it's in obj-c, or invoked in an obj-c manner.